### PR TITLE
Export UntypedType

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export * from './main';
-export { OptionalFieldPattern, Options } from './options';
+export { OptionalFieldPattern, UntypedType, Options } from './options';

--- a/src/options.ts
+++ b/src/options.ts
@@ -76,6 +76,7 @@ const createOptions = (options: PartialDeep<AllOptions>): AllOptions => {
 
 export {
   OptionalFieldPattern,
+  UntypedType,
   AllOptions,
   Options,
   DEFAULT_OPTIONS,


### PR DESCRIPTION
Thanks for the package, it works great!
However, there's currently no way to set the [`UntypedType`](https://github.com/NathanJAdams/json-schema-to-ts#untypedtype) option, because the corresponding enum is not exported. This PR fixes this.